### PR TITLE
Error handling of JSON parsing

### DIFF
--- a/lib/kyc.js
+++ b/lib/kyc.js
@@ -8,7 +8,9 @@ const storage = require("./storage"),
   literals = require("./literals"),
   contract = require("./contract"),
   Deferred = require('./utils/Deferred'),
-  PassThrough = require("stream").PassThrough;
+  PassThrough = require("stream").PassThrough,
+  TokenContractData = require("../contracts/build/Token.json"),
+  help = require("./utils/helpers");
 
 /**
  * Proper bzzr://address for the provided hash.
@@ -117,6 +119,7 @@ const Client = function (web3, network, account, keySet, genSharedSecret) {
   this.account = account;
   this.swarm = new storage.Swarm();
   this.keySet = keySet;
+  this.web3 = web3;
   this.genSharedSecret = genSharedSecret;
 
   let deployment = literals[this.network];
@@ -173,12 +176,18 @@ Client.prototype.uploadAsync = function (document, signTransaction) {
 Client.prototype.download = function (address, callback) {
   let thatPublicKey = this.keySet.byAddress(address);
   if (!thatPublicKey) throw `Can not find an entry by ${address}`;
-
+  
   let sharedSecret = this.genSharedSecret(thatPublicKey);
 
     this._blockchainRead(address, (swarmHash, checksum) => {
         this._download(swarmHash, descriptorString => {
-            let descriptor = JSON.parse(descriptorString);
+            let descriptor = null;
+            try {
+              descriptor = JSON.parse(descriptorString);
+            } catch (error) {
+              callback(error, null);
+              return;
+            }
             let handler = findHandler(descriptor.handlers, sharedSecret);
             if (handler) {
               if (!_.isEqual(checksum, handler.checksum)) throw "Handler and contract contain different checksums";
@@ -282,6 +291,37 @@ Client.prototype._blockchainRead = function (address, callback) {
     callback(swarmHash, checksumBuffer);
   });
 };
+
+Client.prototype.useCurrentToken = function(address, key, action) {
+  this.download(address, (error, document) => {
+      let kycForm = null
+      if (error && document === null) {
+          kycForm = {
+              tokens: [],
+          }
+      } else {
+          kycForm = JSON.parse(document)
+      }
+      if (help.currentTokenExpired()) {
+          let multiplier = help.generateMultiplier()
+          let gasEstimate = this.web3.eth.estimateGas({data: TokenContractData.unlinked_binary})
+          let newToken = this.web3.eth.contract(TokenContractData.abi).new(2000, {
+            from: address, 
+            data: TokenContractData.unlinked_binary, 
+            gas: gasEstimate + 300000
+          })
+          newToken.mult = multiplier
+          kycForm.tokens.push({address: newToken.address, mult: newToken.mult})
+          this.uploadAsync(JSON.stringify(kycForm), (tx) => { tx.sign(key.buffer()); }) 
+          action(newToken)
+      } else {
+          let lastKycRecord = kycForm.tokens[kycForm.tokens.length - 1]
+          let token = this.web3.eth.contract(TokenContractData.abi).at(lastKycRecord.address)
+          token.mult = lastKycRecord.mult
+          action(token)
+      }
+  });
+}
 
 module.exports = {
   Client: Client


### PR DESCRIPTION
When kyc doesn't exist or JSON is malformed it raised an exception instead of passing the error up to the callback